### PR TITLE
Feature/print vm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,3 +79,6 @@ env_logger = "0.9.0"
 [[bench]]
 name = "bench"
 harness = false
+
+[features]
+print = []

--- a/src/melvm/consts.rs
+++ b/src/melvm/consts.rs
@@ -21,6 +21,7 @@ pub const HADDR_SPENDER_INDEX: u16 = 9;
 /// Heap address where the header of the last block is put. If the covenant is being evaluated for a transaction in block N, this is the header of block N-1.
 pub const HADDR_LAST_HEADER: u16 = 10;
 
+pub(crate) const OPCODE_PRINT: u8 = 0x08;
 pub(crate) const OPCODE_NOOP: u8 = 0x09;
 
 pub(crate) const OPCODE_ADD: u8 = 0x10;

--- a/src/melvm/executor.rs
+++ b/src/melvm/executor.rs
@@ -148,15 +148,20 @@ impl Executor {
 
     /// Execute to the end, without popping.
     pub fn run_to_end_preserve_stack(&mut self) -> bool {
+        self.run_discerning_to_end_preserve_stack().unwrap_or(false)
+    }
+
+    /// Execute to the end, without popping.
+    pub fn run_discerning_to_end_preserve_stack(&mut self) -> Option<bool> {
         while self.pc < self.instrs.len() {
             if self.step().is_none() {
-                return false;
+                return None;
             }
         }
-        self.stack
+        Some(self.stack
             .last()
             .map(|f| f.clone().into_bool())
-            .unwrap_or_default()
+            .unwrap_or_default())
     }
 
     /// Checks whether or not the execution has come to an end.
@@ -168,6 +173,7 @@ impl Executor {
     pub fn step(&mut self) -> Option<()> {
         let mut inner = || {
             let op = self.instrs.get(self.pc)?.clone();
+            log::trace!("Getting next instruction {op:?}");
             // eprintln!("OPS: {:?}", self.instrs);
             // eprintln!("PC:  {}", self.pc);
             // eprintln!("OP:  {:?}", op);

--- a/src/melvm/executor.rs
+++ b/src/melvm/executor.rs
@@ -182,6 +182,12 @@ impl Executor {
             self.pc += 1;
             // eprintln!("running {:?}", op);
             match op {
+                #[cfg(feature = "print")]
+                OpCode::Print => self.do_monop(|x| {
+                    println!("{x:?}");
+                    Some(x)
+                    //Some(Value::Int(1u64.into()))
+                })?,
                 OpCode::Noop => {
                     log::trace!("NoOp");
                 }

--- a/src/melvm/opcode.rs
+++ b/src/melvm/opcode.rs
@@ -6,7 +6,7 @@ use crate::melvm::consts::{
     OPCODE_NOT, OPCODE_OR, OPCODE_PUSHB, OPCODE_PUSHI, OPCODE_PUSHIC, OPCODE_REM, OPCODE_SHL,
     OPCODE_SHR, OPCODE_SIGEOK, OPCODE_STORE, OPCODE_STOREIMM, OPCODE_SUB, OPCODE_TYPEQ,
     OPCODE_VAPPEND, OPCODE_VCONS, OPCODE_VEMPTY, OPCODE_VLENGTH, OPCODE_VPUSH, OPCODE_VREF,
-    OPCODE_VSET, OPCODE_VSLICE, OPCODE_XOR,
+    OPCODE_VSET, OPCODE_VSLICE, OPCODE_XOR, OPCODE_PRINT,
 };
 
 use std::{fmt::Display, io::Write};
@@ -16,6 +16,9 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum OpCode {
+    #[cfg(feature = "print")]
+    Print,
+
     Noop,
     // arithmetic
     Add,
@@ -95,6 +98,8 @@ pub enum ParseOpCodeError {
 impl Display for OpCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            #[cfg(feature = "print")]
+            OpCode::Print => "print".fmt(f),
             OpCode::Noop => "noop".fmt(f),
             OpCode::Add => "add".fmt(f),
             OpCode::Sub => "sub".fmt(f),
@@ -180,6 +185,8 @@ impl OpCode {
         let mut output = Vec::new();
 
         match self {
+            #[cfg(feature = "print")]
+            OpCode::Print => output.write_all(&[OPCODE_PRINT]).unwrap(),
             OpCode::Noop => output.write_all(&[OPCODE_NOOP]).unwrap(),
 
             OpCode::Add => output.write_all(&[OPCODE_ADD]).unwrap(),
@@ -304,6 +311,8 @@ impl OpCode {
         };
 
         match read_byte(input)? {
+            #[cfg(feature = "print")]
+            OPCODE_PRINT => Ok(OpCode::Print),
             OPCODE_NOOP => Ok(OpCode::Noop),
             // arithmetic
             OPCODE_ADD => Ok(OpCode::Add),
@@ -415,6 +424,8 @@ fn opcodes_car_weight(opcodes: &[OpCode]) -> (u128, &[OpCode]) {
     }
     let (first, rest) = opcodes.split_first().unwrap();
     match first {
+        #[cfg(feature = "print")]
+        OpCode::Print => (0, rest),
         OpCode::Noop => (1, rest),
         // handle loops specially
         OpCode::Loop(iters, body_len) => {
@@ -1861,6 +1872,16 @@ mod tests {
     fn test_dup() {
         let covenant: Covenant =
             Covenant::from_ops(&[OpCode::PushI(3_u8.into()), OpCode::Dup, OpCode::Eql])
+                .expect("Failed to create a Dup covenant.");
+        let output: bool = covenant.debug_run_without_transaction(&[]);
+
+        assert_eq!(output, true);
+    }
+
+    #[test]
+    fn test_print() {
+        let covenant: Covenant =
+            Covenant::from_ops(&[OpCode::PushI(3_u8.into()), OpCode::Print])
                 .expect("Failed to create a Dup covenant.");
         let output: bool = covenant.debug_run_without_transaction(&[]);
 

--- a/src/melvm/opcode.rs
+++ b/src/melvm/opcode.rs
@@ -1877,14 +1877,4 @@ mod tests {
 
         assert_eq!(output, true);
     }
-
-    #[test]
-    fn test_print() {
-        let covenant: Covenant =
-            Covenant::from_ops(&[OpCode::PushI(3_u8.into()), OpCode::Print])
-                .expect("Failed to create a Dup covenant.");
-        let output: bool = covenant.debug_run_without_transaction(&[]);
-
-        assert_eq!(output, true);
-    }
 }


### PR DESCRIPTION
Add a print opcode as a conditionally compiled feature called `"print"` which pops a value off the stack and returns it after printing.

This makes printing easy in higher level languages that compiles with this feature.