### PR TITLE
Tip 911

### DIFF
--- a/lib/tip911-stakeset/src/lib.rs
+++ b/lib/tip911-stakeset/src/lib.rs
@@ -81,7 +81,7 @@ impl StakeSet {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Tip911 {
     /// Tally of all the SYM that can vote in this epoch.
     pub current_total: CoinValue,

--- a/lib/tip911-stakeset/src/lib.rs
+++ b/lib/tip911-stakeset/src/lib.rs
@@ -103,7 +103,7 @@ impl Tip911 {
                 (
                     self.current_total,
                     self.next_total,
-                    vec[..k].to_vec().stdcode().hash(),
+                    vec[..k].to_vec(),
                 )
                     .stdcode()
             })

--- a/lib/tip911-stakeset/src/lib.rs
+++ b/lib/tip911-stakeset/src/lib.rs
@@ -103,7 +103,7 @@ impl Tip911 {
                 (
                     self.current_total,
                     self.next_total,
-                    vec[..k].to_vec(),
+                    vec[..=k].to_vec(),
                 )
                     .stdcode()
             })

--- a/lib/tip911-stakeset/src/lib.rs
+++ b/lib/tip911-stakeset/src/lib.rs
@@ -81,6 +81,7 @@ impl StakeSet {
     }
 }
 
+#[derive(Debug)]
 pub struct Tip911 {
     /// Tally of all the SYM that can vote in this epoch.
     pub current_total: CoinValue,
@@ -93,19 +94,14 @@ pub struct Tip911 {
 impl Tip911 {
     /// Calculates a dense merkle tree where the kth element is the hash of a stdcode'ed vector of the first k(current_total, next_total, txhash, stakedoc).
     pub fn calculate_merkle(&self) -> DenseMerkleTree {
-        let vec = self
-            .stakes
-            .iter()
-            .map(|(txhash, sdoc)| (txhash, sdoc))
-            .collect::<Vec<_>>();
-        let upto_vec: Vec<Vec<u8>> = (0..vec.len())
+        let upto_vec: Vec<Vec<u8>> = (0..self.stakes.len())
             .map(|k| {
                 (
                     self.current_total,
                     self.next_total,
-                    vec[..=k].to_vec(),
+                    self.stakes[..=k].to_vec(),
                 )
-                    .stdcode()
+                .stdcode()
             })
             .collect();
         DenseMerkleTree::new(&upto_vec)


### PR DESCRIPTION
Removed hashing in stakes tree datablock creation, made the vec slice range inclusive, added impls, and simplified some logic.